### PR TITLE
Fix content collection slug validation

### DIFF
--- a/src/content/articles/test.mdx
+++ b/src/content/articles/test.mdx
@@ -1,4 +1,3 @@
-// src/content/articles/test.mdx
 ---
 title: "Test Article"
 slug: "test-article"

--- a/src/content/config.ts
+++ b/src/content/config.ts
@@ -38,7 +38,6 @@ const playbooks = defineCollection({
   type: "content",
   schema: z.object({
     title: z.string(),
-    slug: z.string(),
     date: z.string().optional(), // ISO date
     summary: z.string().optional(),
     tags: z.array(z.string()).default([]),
@@ -50,7 +49,6 @@ const articles = defineCollection({
   type: "content",
   schema: z.object({
     title: z.string(),
-    slug: z.string(),
     date: z.string().optional(),      // ISO date
     summary: z.string().optional(),
     tags: z.array(z.string()).default([]),


### PR DESCRIPTION
## Summary
- remove slug fields from content schemas to match Astro's handling
- tidy placeholder article front matter

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a76a10db7c833094f9c1fe0f74adcf