### PR TITLE
feat: add transformation streams and case studies

### DIFF
--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -5,10 +5,13 @@
   <div class="mx-auto max-w-6xl px-6 md:px-8 h-16 flex items-center justify-between">
     <a href="/" class="font-heading text-lg md:text-xl font-semibold no-underline">SMooks</a>
     <nav class="hidden md:flex gap-6">
+      <a href="/streams">Streams</a>
+      <a href="/case-studies">Case Studies</a>
       <a href="/system-wins">Systems Wins</a>
       <a href="/playbooks">Playbooks</a>
       <a href="/writing">Writing</a>
       <a href="/about">About</a>
+      <a href="/evidence/matrix">Matrix</a>
     </nav>
     <div class="flex items-center gap-3">
       <a href="/contact" class="btn btn-secondary">Contact</a>

--- a/src/content/case-studies/_template.md
+++ b/src/content/case-studies/_template.md
@@ -1,0 +1,39 @@
+---
+title: "${Title}"
+year: "${Year}"
+organisation: "${Org}"
+stream: ${one-of}
+# tech-digital | people-culture | systems-automation | ops-modernisation | education-learning | leadership-governance | innovation-growth
+summary: "One‑line impact."
+impact:
+  - { label: "Hours saved", value: "12,000+" }
+  - { label: "Engagement", value: "90%" }
+scale: "7 schools, ~800 staff"
+longevity: "Still in use (2025)"
+cmi_units: ["701","705","709"]
+tags: ["M365","SharePoint","Power Automate"]
+links:
+  - { label: "Related stream", url: "/streams/ops-modernisation" }
+status: published
+heroImage: "/images/case/slug/hero.jpg"
+heroAlt: ""
+seo:
+  title: "${SEO title override}"
+  description: "${SEO meta description}"
+---
+
+## Context / Challenge
+
+## Strategy / Approach
+- Frameworks used: MoSCoW, Kotter, Risk matrix, ISO 27001/20000 lens
+
+## Actions
+- Step 1 …
+- Step 2 …
+
+## Impact
+- Metrics: …
+- Adoption: …
+
+## Reflection
+- What I’d do again / differently; leadership takeaway

--- a/src/content/case-studies/daily-daysheet-standard.md
+++ b/src/content/case-studies/daily-daysheet-standard.md
@@ -1,0 +1,30 @@
+---
+title: "Daily Daysheet Standard"
+year: "2024"
+organisation: "Outcomes First Group"
+stream: ops-modernisation
+summary: "Protected ~12,000 staff hours annually by standardising daily operations across sites."
+impact:
+  - { label: "Hours saved", value: "12,000+/yr" }
+  - { label: "Adoption", value: "7+ schools" }
+scale: "Regional rollout"
+longevity: "Still in use (2025)"
+cmi_units: ["705","707","709"]
+tags: ["standard work","SharePoint","governance"]
+status: published
+---
+
+## Context / Challenge
+Handover gaps, inconsistent daily routines, duplicated comms → wasted time.
+
+## Strategy / Approach
+- Standard work + light IA in SharePoint; MoSCoW to prioritise must‑haves.
+
+## Actions
+…
+
+## Impact
+- ~12,000 hours saved annually (conservative). Fewer missed actions.
+
+## Reflection
+…

--- a/src/content/case-studies/internal-job-board.md
+++ b/src/content/case-studies/internal-job-board.md
@@ -1,0 +1,18 @@
+---
+title: "Internal Job Board (M365-native)"
+year: "2025"
+organisation: "Outcomes First Group"
+stream: tech-digital
+summary: "Built M365‑native job board (Lists + Power Automate) for transparent mobility and leadership visibility."
+impact:
+  - { label: "Time to fill", value: "↓ (target)" }
+  - { label: "Visibility", value: "↑ across 80 sites" }
+scale: "Group‑wide"
+longevity: "Resumable solution"
+cmi_units: ["701","702","704"]
+tags: ["M365","Lists","Power Automate","talent"]
+status: draft
+---
+
+## Context / Challenge
+…

--- a/src/content/case-studies/legionella-compliance-platform.md
+++ b/src/content/case-studies/legionella-compliance-platform.md
@@ -1,0 +1,16 @@
+---
+title: "Legionella Compliance Platform (Rybro)"
+year: "2013"
+organisation: "Rybro"
+stream: ops-modernisation
+summary: "End‑to‑end logging/reporting to meet L8 ACOP; faster certification; risk reduced."
+impact:
+  - { label: "Certification cycle time", value: "↓" }
+  - { label: "Non‑compliance risk", value: "↓" }
+cmi_units: ["708","716"]
+tags: ["H&S","compliance","field ops"]
+status: published
+---
+
+## Context / Challenge
+…

--- a/src/content/case-studies/raci-hats-framework.md
+++ b/src/content/case-studies/raci-hats-framework.md
@@ -1,0 +1,16 @@
+---
+title: "RACI Hats Framework"
+year: "2023"
+organisation: "Outcomes First Group"
+stream: leadership-governance
+summary: "Clarified decision rights; reduced cross‑team ambiguity via scalable framework + BI dashboards."
+impact:
+  - { label: "Decision latency", value: "↓ significantly" }
+  - { label: "Adoption", value: "SLT + teams" }
+cmi_units: ["701","704","707"]
+tags: ["governance","Power BI","RACI"]
+status: published
+---
+
+## Context / Challenge
+…

--- a/src/content/case-studies/regional-staff-awards.md
+++ b/src/content/case-studies/regional-staff-awards.md
@@ -1,0 +1,17 @@
+---
+title: "Regional Staff Awards — Student‑Built System"
+year: "2025"
+organisation: "Outcomes First Group"
+stream: innovation-growth
+summary: "90% engagement; 1,147 nominations; recognition platform delivered by neurodivergent students."
+impact:
+  - { label: "Engagement", value: "~90%" }
+  - { label: "Nominations", value: "1,147" }
+  - { label: "Schools", value: "7" }
+cmi_units: ["703","711","712","716"]
+tags: ["Power Automate","behavioural design","recognition"]
+status: draft
+---
+
+## Context / Challenge
+…

--- a/src/content/config.ts
+++ b/src/content/config.ts
@@ -61,10 +61,53 @@ const articles = defineCollection({
   }),
 });
 
+const caseStudies = defineCollection({
+  type: "content",
+  schema: z.object({
+    title: z.string(),
+    slug: z.string().optional(),
+    year: z.string().describe("e.g., 2025 or 2013–2015"),
+    organisation: z.string().optional(),
+    stream: z.enum([
+      "tech-digital",
+      "people-culture",
+      "systems-automation",
+      "ops-modernisation",
+      "education-learning",
+      "leadership-governance",
+      "innovation-growth",
+    ]),
+    tags: z.array(z.string()).default([]),
+    summary: z.string(),
+    impact: z.array(
+      z.object({
+        label: z.string(),
+        value: z.string(), // '12,000+ hours saved', '90% engagement', '~30% reduction'
+      })
+    ).default([]),
+    scale: z.string().optional(), // '#users/sites/staff'
+    longevity: z.string().optional(), // 'still in use', 'scaled to 7 schools'
+    cmi_units: z.array(z.string()).default([]), // e.g., ['701','705','709']
+    links: z.array(z.object({ label: z.string(), url: z.string() })).default([]),
+    status: z.enum(["draft", "published"]).default("published"),
+    heroImage: z.string().optional(),
+    heroAlt: z.string().optional(),
+    seo: z
+      .object({
+        title: z.string().optional(),
+        description: z.string().optional(),
+      })
+      .optional(),
+  }),
+});
+
 
 
 
 export const collections = {
   // keep existing collections here (e.g., wins, articles) if defined
-  playbooks, wins, articles
+  playbooks,
+  wins,
+  articles,
+  "case-studies": caseStudies,
 };

--- a/src/pages/case-studies/[...slug].astro
+++ b/src/pages/case-studies/[...slug].astro
@@ -1,0 +1,77 @@
+---
+import BaseLayout from "@/layouts/BaseLayout.astro";
+import { getCollection } from 'astro:content';
+
+export async function getStaticPaths() {
+  const entries = await getCollection('case-studies');
+  return entries.map((e) => ({ params: { slug: e.slug } }));
+}
+
+const entries = await getCollection('case-studies');
+const slug = Array.isArray(Astro.params.slug) ? Astro.params.slug.join('/') : Astro.params.slug;
+const entry = entries.find(e => e.slug === slug);
+const data = entry!.data;
+const { Content } = await entry!.render();
+const title = data.seo?.title ?? data.title;
+const description = data.seo?.description ?? data.summary;
+
+const STREAM_LABELS: Record<string,string> = {
+  'tech-digital':'Technology & Digital Transformation',
+  'people-culture':'People, Culture & Community',
+  'systems-automation':'Systems & Automation',
+  'ops-modernisation':'Operational Efficiency & Modernisation',
+  'education-learning':'Education & Learning',
+  'leadership-governance':'Leadership, Strategy & Governance',
+  'innovation-growth':'Innovation & Growth',
+};
+
+const jsonLd = {
+  '@context': 'https://schema.org',
+  '@type': 'Article',
+  headline: data.title,
+  description: description,
+  datePublished: data.year,
+  author: { '@type': 'Person', name: 'Sharron Mooks' },
+  keywords: [...(data.tags||[])].join(', '),
+};
+
+const breadcrumb = {
+  '@context': 'https://schema.org',
+  '@type': 'BreadcrumbList',
+  itemListElement: [
+    { '@type': 'ListItem', position: 1, name: 'Streams', item: '/streams' },
+    { '@type': 'ListItem', position: 2, name: STREAM_LABELS[data.stream], item: `/streams/${data.stream}` },
+    { '@type': 'ListItem', position: 3, name: data.title, item: `/case-studies/${entry?.slug}` },
+  ],
+};
+---
+<BaseLayout title={title} description={description}>
+  <article class="container mx-auto px-4 py-10 prose dark:prose-invert max-w-3xl">
+    <header class="mb-6">
+      <p class="text-sm text-gray-500">{data.year} · {data.organisation}</p>
+      <h1 class="!mb-2">{data.title}</h1>
+      <p class="text-gray-600 dark:text-gray-300">{data.summary}</p>
+      <div class="mt-4 flex flex-wrap gap-2 text-xs">
+        {data.cmi_units?.map(u => <span class="border px-2 py-1 rounded-full">CMI {u}</span>)}
+        {data.tags?.map(t => <span class="border px-2 py-1 rounded-full">{t}</span>)}
+      </div>
+    </header>
+
+    <Content />
+
+    <section class="mt-8">
+      <h2>Impact</h2>
+      <ul class="grid sm:grid-cols-2 gap-3">
+        {data.impact?.map(i => <li class="border rounded-xl p-3"><strong>{i.label}:</strong> {i.value}</li>)}
+      </ul>
+      {data.scale && <p class="mt-4 text-sm"><strong>Scale:</strong> {data.scale}</p>}
+      {data.longevity && <p class="text-sm"><strong>Longevity:</strong> {data.longevity}</p>}
+    </section>
+
+    <footer class="mt-10">
+      <a href={`/streams/${data.stream}`} class="text-sm underline">← Back to stream</a>
+    </footer>
+  </article>
+  <script type="application/ld+json">{JSON.stringify(jsonLd)}</script>
+  <script type="application/ld+json">{JSON.stringify(breadcrumb)}</script>
+</BaseLayout>

--- a/src/pages/case-studies/index.astro
+++ b/src/pages/case-studies/index.astro
@@ -1,0 +1,22 @@
+---
+import BaseLayout from "@/layouts/BaseLayout.astro";
+import { getCollection } from 'astro:content';
+const all = await getCollection('case-studies', ({ data }) => data.status !== 'draft');
+---
+<BaseLayout title="Case Studies">
+  <section class="container mx-auto px-4 py-10">
+    <h1 class="text-3xl md:text-4xl font-semibold mb-6">Case Studies</h1>
+    <div class="grid md:grid-cols-2 gap-6">
+      {all.map(({ slug, data }) => (
+        <a href={`/case-studies/${slug}`}
+           class="block rounded-2xl p-6 shadow-sm hover:shadow-md transition border border-gray-200 bg-white dark:bg-zinc-900">
+          <h2 class="text-xl font-medium mb-2">{data.title}</h2>
+          <p class="text-sm text-gray-600 dark:text-gray-400">{data.summary}</p>
+          <div class="mt-3 flex flex-wrap gap-2 text-xs">
+            {data.impact?.slice(0,3).map(i => <span class="border px-2 py-1 rounded-full">{i.label}: {i.value}</span>)}
+          </div>
+        </a>
+      ))}
+    </div>
+  </section>
+</BaseLayout>

--- a/src/pages/evidence/matrix.astro
+++ b/src/pages/evidence/matrix.astro
@@ -1,0 +1,31 @@
+---
+import BaseLayout from '@/layouts/BaseLayout.astro';
+import { getCollection } from 'astro:content';
+const entries = await getCollection('case-studies');
+const UNITS = ['701','702','703','704','705','706','707','708','709','710','711','712','713','714','715','716'];
+---
+<BaseLayout title="Portfolio × CMI Matrix">
+  <section class="container mx-auto px-4 py-10">
+    <h1 class="text-3xl md:text-4xl font-semibold mb-6">Portfolio × CMI Evidence Matrix</h1>
+    <div class="overflow-x-auto border rounded-2xl">
+      <table class="min-w-[900px] w-full text-sm">
+        <thead class="bg-gray-50 dark:bg-zinc-900">
+          <tr>
+            <th class="text-left p-3">Project</th>
+            {UNITS.map(u => <th class="p-3 text-center">{u}</th>)}
+          </tr>
+        </thead>
+        <tbody>
+          {entries.map(e => (
+            <tr class="border-t">
+              <td class="p-3"><a href={`/case-studies/${e.slug}`} class="underline">{e.data.title}</a></td>
+              {UNITS.map(u => (
+                <td class="p-3 text-center">{e.data.cmi_units?.includes(u) ? '✅' : ''}</td>
+              ))}
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  </section>
+</BaseLayout>

--- a/src/pages/streams/[stream].astro
+++ b/src/pages/streams/[stream].astro
@@ -1,0 +1,37 @@
+---
+import BaseLayout from "@/layouts/BaseLayout.astro";
+import { getCollection } from 'astro:content';
+export async function getStaticPaths() {
+  return [
+    'tech-digital','people-culture','systems-automation','ops-modernisation','education-learning','leadership-governance','innovation-growth'
+  ].map(s => ({ params: { stream: s } }));
+}
+const { stream } = Astro.params;
+const all = await getCollection('case-studies', ({ data }) => data.stream === stream && data.status !== 'draft');
+const LABELS: Record<string,string> = {
+  'tech-digital':'Technology & Digital Transformation',
+  'people-culture':'People, Culture & Community',
+  'systems-automation':'Systems & Automation',
+  'ops-modernisation':'Operational Efficiency & Modernisation',
+  'education-learning':'Education & Learning',
+  'leadership-governance':'Leadership, Strategy & Governance',
+  'innovation-growth':'Innovation & Growth',
+};
+---
+<BaseLayout title={`${LABELS[stream]} — Case Studies`}>
+  <section class="container mx-auto px-4 py-10">
+    <h1 class="text-3xl md:text-4xl font-semibold mb-6">{LABELS[stream]}</h1>
+    <div class="grid md:grid-cols-2 gap-6">
+      {all.map(({ slug, data }) => (
+        <a href={`/case-studies/${slug}`}
+           class="block rounded-2xl p-6 shadow-sm hover:shadow-md transition border border-gray-200 bg-white dark:bg-zinc-900">
+          <h2 class="text-xl font-medium mb-2">{data.title}</h2>
+          <p class="text-sm text-gray-600 dark:text-gray-400">{data.summary}</p>
+          <div class="mt-3 flex flex-wrap gap-2 text-xs">
+            {data.impact?.slice(0,3).map(i => <span class="border px-2 py-1 rounded-full">{i.label}: {i.value}</span>)}
+          </div>
+        </a>
+      ))}
+    </div>
+  </section>
+</BaseLayout>

--- a/src/pages/streams/index.astro
+++ b/src/pages/streams/index.astro
@@ -1,0 +1,32 @@
+---
+import BaseLayout from "@/layouts/BaseLayout.astro";
+import { getCollection } from 'astro:content';
+const all = await getCollection('case-studies');
+const byStream = all.reduce((acc, item) => {
+  const s = item.data.stream; (acc[s] ||= []).push(item);
+  return acc;
+}, {} as Record<string, typeof all>);
+const STREAMS = [
+  { key: 'tech-digital', label: 'Technology & Digital Transformation' },
+  { key: 'people-culture', label: 'People, Culture & Community' },
+  { key: 'systems-automation', label: 'Systems & Automation' },
+  { key: 'ops-modernisation', label: 'Operational Efficiency & Modernisation' },
+  { key: 'education-learning', label: 'Education & Learning' },
+  { key: 'leadership-governance', label: 'Leadership, Strategy & Governance' },
+  { key: 'innovation-growth', label: 'Innovation & Growth' },
+];
+---
+<BaseLayout title="Transformation Streams">
+  <section class="container mx-auto px-4 py-10">
+    <h1 class="text-3xl md:text-4xl font-semibold mb-6">Transformation Streams</h1>
+    <p class="mb-10 max-w-3xl">Browse case studies by stream. Each story links to CMI Level 7 evidence and metrics.</p>
+    <div class="grid md:grid-cols-2 lg:grid-cols-3 gap-6">
+      {STREAMS.map(s => (
+        <a href={`/streams/${s.key}`} class="block rounded-2xl p-6 shadow-sm hover:shadow-md transition border border-gray-200 bg-white dark:bg-zinc-900">
+          <h2 class="text-xl font-medium mb-2">{s.label}</h2>
+          <p class="text-sm text-gray-600 dark:text-gray-400">{byStream[s.key]?.length ?? 0} case studies</p>
+        </a>
+      ))}
+    </div>
+  </section>
+</BaseLayout>


### PR DESCRIPTION
## Summary
- add `case-studies` content collection with schema and seed entries
- implement stream and case study pages plus CMI evidence matrix
- extend site navigation with Streams, Case Studies, and Matrix links

## Testing
- `pnpm build`

------
https://chatgpt.com/codex/tasks/task_e_68ab3d499140833093b2492f91518479