### PR TITLE
Add frontmatter template docs

### DIFF
--- a/docs/frontmatter-templates.md
+++ b/docs/frontmatter-templates.md
@@ -1,0 +1,22 @@
+---
+# Frontmatter Templates
+---
+
+```markdown
+---
+title: ""
+description: ""
+date: "2025-08-24"
+updated: ""
+tags: []
+hero: "/images/...jpg"
+alt: ""
+context: ""
+action: ""
+outcome: ""
+strategicValue: ""
+cmiUnits: ["701", "703", "705", "704", "708", "610"]
+relatedWins: []
+relatedWriting: []
+---
+```


### PR DESCRIPTION
## Summary
- add frontmatter template markdown for authors

## Testing
- `npm run build`
- `npx astro check` *(fails: requires @astrojs/check and typescript)*

------
https://chatgpt.com/codex/tasks/task_e_68ab4a6a73588330ba616b1256b6ff5c