### PR TITLE
feat: unify content collections with shared metadata

### DIFF
--- a/src/content/config.ts
+++ b/src/content/config.ts
@@ -1,113 +1,54 @@
 import { defineCollection, z } from "astro:content";
 
-const wins = defineCollection({
-  type: "content",
-  schema: z.object({
-    title: z.string(),
-    date: z.coerce.date(),
-    summary: z.string().max(220),
-    tags: z.array(z.string()).default([]),
-    role: z.string().optional(),
-    organisation: z.string().optional(),
-    outcomes: z.array(z.string()).optional(),
-    impact_metrics: z.array(z.object({
-      metric: z.string(),
-      before: z.string().optional(),
-      after: z.string().optional(),
-      estimate_hours: z.number().optional()
-    })).optional(),
-    links: z.array(z.object({
-      label: z.string(),
-      url: z.string().url()
-    })).optional(),
-    media: z.array(z.object({
-      src: z.string(),
-      alt: z.string(),
-      caption: z.string().optional()
-    })).optional(),
-    standards_alignment: z.object({
-      iso: z.array(z.string()).optional(),
-      frameworks: z.array(z.string()).optional(),
-      cmi_evidence: z.array(z.string()).optional()
-    }).optional(),
-    draft: z.boolean().default(false).optional(),
-  }),
-});
-
-
-const playbooks = defineCollection({
-  type: "content",
-  schema: z.object({
-    title: z.string(),
-//    slug: z.string(),
-    date: z.coerce.date(), // ISO date
-    summary: z.string().optional(),
-    tags: z.array(z.string()).default([]),
-    draft: z.boolean().default(false).optional(),
-  }),
-});
-
-
-const articles = defineCollection({
-  type: "content",
-  schema: z.object({
-    title: z.string(),
-//    slug: z.string(),
-    date: z.coerce.date(),      // ISO date
-    summary: z.string().optional(),
-    tags: z.array(z.string()).default([]),
-    canonical: z.string().url().optional(),
-    draft: z.boolean().default(false).optional(),
-  }),
-});
+const sharedFields = {
+  title: z.string(),
+  summary: z.string().max(280, "Use a tight, scannable summary"),
+  year: z.number().int().min(2000).max(2100),
+  category: z.array(z.string()).default([]),   // e.g. ["Culture","Digital Transformation"]
+  tags: z.array(z.string()).default([]),       // e.g. ["Awards","SharePoint","CMI-705"]
+  featured: z.boolean().default(false),        // for homepage spotlights
+  // Optional extras (used on cards, SERP snippets)
+  thumbnail: z.string().optional(),            // /images/...
+  publishedAt: z.string().optional(),          // ISO 8601 (fallback to file name date)
+  updatedAt: z.string().optional(),
+  // CMI alignment (free text or unit codes)
+  cmi: z.array(z.string()).default([]),        // ["701","703","705","708","610"]
+  // SEO
+  keywords: z.array(z.string()).default([]),
+};
 
 const caseStudies = defineCollection({
   type: "content",
   schema: z.object({
-    title: z.string(),
-    slug: z.string().optional(),
-    year: z.string().describe("e.g., 2025 or 2013–2015"),
-    organisation: z.string().optional(),
-    stream: z.enum([
-      "tech-digital",
-      "people-culture",
-      "systems-automation",
-      "ops-modernisation",
-      "education-learning",
-      "leadership-governance",
-      "innovation-growth",
-    ]),
-    tags: z.array(z.string()).default([]),
-    summary: z.string(),
-    impact: z.array(
-      z.object({
-        label: z.string(),
-        value: z.string(), // '12,000+ hours saved', '90% engagement', '~30% reduction'
-      })
-    ).default([]),
-    scale: z.string().optional(), // '#users/sites/staff'
-    longevity: z.string().optional(), // 'still in use', 'scaled to 7 schools'
-    cmi_units: z.array(z.string()).default([]), // e.g., ['701','705','709']
-    links: z.array(z.object({ label: z.string(), url: z.string() })).default([]),
-    status: z.enum(["draft", "published"]).default("published"),
-    heroImage: z.string().optional(),
-    heroAlt: z.string().optional(),
-    seo: z
-      .object({
-        title: z.string().optional(),
-        description: z.string().optional(),
-      })
-      .optional(),
+    ...sharedFields,
+    type: z.literal("Case Study").default("Case Study"),
+    outcome: z
+      .array(
+        z.object({
+          label: z.string(),           // "Nominations"
+          value: z.string(),           // "1,147"
+        })
+      )
+      .default([]),
   }),
 });
 
+const systemWins = defineCollection({
+  type: "content",
+  schema: z.object({
+    ...sharedFields,
+    type: z.literal("System Win").default("System Win"),
+    metric: z.string().optional(),     // "12,000+ hours saved"
+  }),
+});
 
+const writing = defineCollection({
+  type: "content",
+  schema: z.object({
+    ...sharedFields,
+    type: z.literal("Writing").default("Writing"),
+    canonical: z.string().url().optional(), // link to LinkedIn/original
+  }),
+});
 
-
-export const collections = {
-  // keep existing collections here (e.g., wins, articles) if defined
-  playbooks,
-  wins,
-  articles,
-  "case-studies": caseStudies,
-};
+export const collections = { caseStudies, systemWins, writing };


### PR DESCRIPTION
## Summary
- normalize content collections with shared metadata fields
- add dedicated schemas for case studies, system wins, and writing

## Testing
- `pnpm build` *(warn: The collection "system-wins" does not exist or is empty)*

------
https://chatgpt.com/codex/tasks/task_e_68ab4d29d34c83308470857ba67426fa