### PR TITLE
feat: add detail pages and related content

### DIFF
--- a/src/components/RelatedContent.astro
+++ b/src/components/RelatedContent.astro
@@ -1,0 +1,48 @@
+---
+import { getCollection } from "astro:content";
+import { slugify } from "@/utils/slugify";
+
+const { currentSlug, currentType, tags = [], year } = Astro.props as {
+  currentSlug: string; currentType: "Case Study" | "System Win" | "Writing"; tags?: string[]; year?: number;
+};
+
+const pools = {
+  "Case Study": await getCollection("caseStudies"),
+  "System Win": await getCollection("systemWins"),
+  "Writing": await getCollection("writing"),
+};
+
+const list = pools[currentType]
+  .filter((e) => (e.slug ?? e.id) !== currentSlug)
+  .map((e) => ({
+    slug: slugify(e.slug ?? e.id ?? e.data.title),
+    title: e.data.title,
+    summary: e.data.summary,
+    tags: e.data.tags ?? [],
+    year: e.data.year,
+  }))
+  .map((i) => {
+    const tagScore = i.tags.filter((t) => tags.includes(t)).length;
+    const yearScore = year ? Math.max(0, 3 - Math.abs((i.year ?? 0) - year)) : 0;
+    return { ...i, score: tagScore * 2 + yearScore };
+  })
+  .sort((a, b) => b.score - a.score)
+  .slice(0, 3);
+---
+
+{list.length ? (
+  <aside class="mt-12">
+    <h3 class="text-lg font-semibold">Related</h3>
+    <ul class="mt-3 grid gap-4 sm:grid-cols-2">
+      {list.map((i) => (
+        <li>
+          <a href={`/${currentType === "Writing" ? "writing" : currentType === "System Win" ? "system-wins" : "portfolio"}/${i.slug}`} class="block rounded-2xl border p-4 hover:shadow-lg transition">
+            <div class="text-xs text-gray-500">{i.year}</div>
+            <div class="font-medium">{i.title}</div>
+            <p class="mt-1 text-sm text-gray-600">{i.summary}</p>
+          </a>
+        </li>
+      ))}
+    </ul>
+  </aside>
+) : null}

--- a/src/layouts/Base.astro
+++ b/src/layouts/Base.astro
@@ -1,0 +1,18 @@
+---
+const { title = "SMooks", description = "Strategic Systems Architect & Transformation Leader", canonical, meta = [] } = Astro.props as {
+  title?: string; description?: string; canonical?: string; meta?: {name?:string; property?:string; content:string}[];
+};
+---
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width,initial-scale=1" />
+    <title>{title}</title>
+    <meta name="description" content={description} />
+    {canonical && <link rel="canonical" href={canonical} />}
+    {meta.map((m) => <meta {...m} />)}
+  </head>
+  <body class="min-h-screen bg-white text-gray-900 antialiased">
+    <slot />
+  </body>
+</html>

--- a/src/lib/seo.ts
+++ b/src/lib/seo.ts
@@ -1,0 +1,78 @@
+export function buildPieceMeta({
+  title,
+  description,
+  url,
+  type,
+  image,
+}: {
+  title: string;
+  description: string;
+  url: string;
+  type: string;
+  image?: string;
+}) {
+  const meta = [
+    { property: "og:title", content: title },
+    { property: "og:description", content: description },
+    { property: "og:type", content: type },
+    { property: "og:url", content: url },
+    image ? { property: "og:image", content: image } : null,
+    { name: "twitter:card", content: "summary_large_image" },
+    { name: "twitter:title", content: title },
+    { name: "twitter:description", content: description },
+    image ? { name: "twitter:image", content: image } : null,
+  ].filter(Boolean) as { name?: string; property?: string; content: string }[];
+
+  return { title, description, canonical: url, meta };
+}
+
+export function pieceJsonLd({
+  title,
+  description,
+  url,
+  image,
+  datePublished,
+  dateModified,
+  keywords,
+  authorName,
+  type,
+}: {
+  title: string;
+  description: string;
+  url: string;
+  image?: string;
+  datePublished?: string;
+  dateModified?: string;
+  keywords?: string[];
+  authorName: string;
+  type: string;
+}) {
+  return {
+    "@context": "https://schema.org",
+    "@type": type,
+    headline: title,
+    description,
+    url,
+    image,
+    datePublished,
+    dateModified,
+    keywords,
+    author: {
+      "@type": "Person",
+      name: authorName,
+    },
+  };
+}
+
+export function breadcrumbJsonLd(items: { name: string; url: string }[]) {
+  return {
+    "@context": "https://schema.org",
+    "@type": "BreadcrumbList",
+    itemListElement: items.map((item, index) => ({
+      "@type": "ListItem",
+      position: index + 1,
+      name: item.name,
+      item: item.url,
+    })),
+  };
+}

--- a/src/pages/portfolio/[slug].astro
+++ b/src/pages/portfolio/[slug].astro
@@ -6,11 +6,11 @@ import { slugify } from "@/utils/slugify";
 import { buildPieceMeta, pieceJsonLd, breadcrumbJsonLd } from "@/lib/seo";
 
 export async function getStaticPaths() {
-  const entries = await getCollection("systemWins");
+  const entries = await getCollection("caseStudies");
   return entries.map((e) => ({ params: { slug: slugify(e.slug ?? e.id ?? e.data.title) } }));
 }
 
-const all = await getCollection("systemWins");
+const all = await getCollection("caseStudies");
 const slug = Astro.params.slug!;
 const entry = all.find((e) => slugify(e.slug ?? e.id ?? e.data.title) === slug);
 if (!entry) throw new Error("Not found");
@@ -18,7 +18,7 @@ if (!entry) throw new Error("Not found");
 const { Content } = await entry.render();
 const url = new URL(Astro.request.url);
 const meta = buildPieceMeta({
-  title: `${entry.data.title} — System Win | SMooks`,
+  title: `${entry.data.title} — Case Study | SMooks`,
   description: entry.data.summary,
   url: url.toString(),
   type: "article",
@@ -33,10 +33,14 @@ const meta = buildPieceMeta({
     </nav>
 
     <header>
-      <div class="text-sm text-gray-500">{entry.data.year} · System Win</div>
+      <div class="text-sm text-gray-500">{entry.data.year} · Case Study</div>
       <h1 class="mt-1 text-3xl font-bold">{entry.data.title}</h1>
       <p class="mt-3 text-gray-700">{entry.data.summary}</p>
-      {entry.data.metric && <div class="mt-3 text-sm font-medium">{entry.data.metric}</div>}
+      {entry.data.outcome?.length ? (
+        <ul class="mt-4 flex flex-wrap gap-2">
+          {entry.data.outcome.map((o:any) => <li class="rounded-full bg-gray-100 px-3 py-1 text-sm">{o.label}: <strong>{o.value}</strong></li>)}
+        </ul>
+      ) : null}
       <div class="mt-4 flex flex-wrap gap-1">
         {(entry.data.tags ?? []).map((t:string) => <span class="rounded-full bg-gray-50 border px-2 py-0.5 text-xs">#{t}</span>)}
       </div>
@@ -46,7 +50,7 @@ const meta = buildPieceMeta({
       <Content />
     </div>
 
-    <RelatedContent currentSlug={slug} currentType="System Win" tags={entry.data.tags} year={entry.data.year} />
+    <RelatedContent currentSlug={slug} currentType="Case Study" tags={entry.data.tags} year={entry.data.year} />
   </article>
 
   <script type="application/ld+json" set:html={JSON.stringify(pieceJsonLd({
@@ -58,7 +62,7 @@ const meta = buildPieceMeta({
     dateModified: entry.data.updatedAt,
     keywords: entry.data.keywords,
     authorName: "Sharron Mooks",
-    type: "CreativeWork",
+    type: "Article",
   }))}/>
   <script type="application/ld+json" set:html={JSON.stringify(breadcrumbJsonLd([
     { name: "Home", url: new URL("/", url).toString() },

--- a/src/pages/writing/[slug].astro
+++ b/src/pages/writing/[slug].astro
@@ -1,41 +1,68 @@
 ---
-// src/pages/writing/[slug].astro
-export const prerender = true;
-
-import Layout from "../../layouts/BaseLayout.astro";
+import Base from "@/layouts/Base.astro";
 import { getCollection } from "astro:content";
+import RelatedContent from "@/components/RelatedContent.astro";
+import { slugify } from "@/utils/slugify";
+import { buildPieceMeta, pieceJsonLd, breadcrumbJsonLd } from "@/lib/seo";
 
 export async function getStaticPaths() {
-  // returns [] if the collection exists but is empty — which is fine
-  const entries = await getCollection("articles");
-  return entries.map((entry) => ({
-    params: { slug: entry.slug },
-    props: { entry },
-  }));
+  const entries = await getCollection("writing");
+  return entries.map((e) => ({ params: { slug: slugify(e.slug ?? e.id ?? e.data.title) } }));
 }
 
-const { entry } = Astro.props as { entry: any };
+const all = await getCollection("writing");
+const slug = Astro.params.slug!;
+const entry = all.find((e) => slugify(e.slug ?? e.id ?? e.data.title) === slug);
+if (!entry) throw new Error("Not found");
+
 const { Content } = await entry.render();
-
-const title = entry.data.title ?? `Article: ${entry.slug}`;
-const description = entry.data.summary ?? "Article";
+const url = new URL(Astro.request.url);
+const meta = buildPieceMeta({
+  title: `${entry.data.title} — Writing | SMooks`,
+  description: entry.data.summary,
+  url: url.toString(),
+  type: "article",
+  image: entry.data.thumbnail,
+});
 ---
-<Layout {title} {description} currentPath={Astro.url.pathname}>
-  <section class="mx-auto max-w-3xl">
-    <a href="/writing" class="text-sm text-zinc-400 hover:underline">← Back to Writing</a>
-    <h1 class="mt-2 text-3xl md:text-4xl font-semibold">{title}</h1>
-    {entry.data.summary && <p class="mt-2 text-zinc-400">{entry.data.summary}</p>}
 
-    <article class="prose prose-invert max-w-none mt-8">
-      <Content />
-    </article>
+<Base title={meta.title} description={meta.description} canonical={meta.canonical} meta={meta.meta}>
+  <article class="mx-auto max-w-3xl px-4 sm:px-6 lg:px-8 py-12">
+    <nav class="mb-6 text-sm text-gray-600">
+      <a href="/">Home</a> · <a href="/writing">Writing</a> · <span class="text-gray-900">{entry.data.title}</span>
+    </nav>
 
-    {entry.data.tags?.length > 0 && (
-      <div class="mt-8 flex flex-wrap gap-2">
-        {entry.data.tags.map((t: string) => (
-          <span class="text-[11px] px-2 py-1 rounded-full bg-white/5 border border-white/10">{t}</span>
-        ))}
+    <header>
+      <div class="text-sm text-gray-500">{entry.data.year} · Writing</div>
+      <h1 class="mt-1 text-3xl font-bold">{entry.data.title}</h1>
+      <p class="mt-3 text-gray-700">{entry.data.summary}</p>
+      {entry.data.canonical && <div class="mt-2 text-sm"><a class="underline" href={entry.data.canonical}>Original publication</a></div>}
+      <div class="mt-4 flex flex-wrap gap-1">
+        {(entry.data.tags ?? []).map((t:string) => <span class="rounded-full bg-gray-50 border px-2 py-0.5 text-xs">#{t}</span>)}
       </div>
-    )}
-  </section>
-</Layout>
+    </header>
+
+    <div class="prose prose-zinc mt-8 max-w-none">
+      <Content />
+    </div>
+
+    <RelatedContent currentSlug={slug} currentType="Writing" tags={entry.data.tags} year={entry.data.year} />
+  </article>
+
+  <script type="application/ld+json" set:html={JSON.stringify(pieceJsonLd({
+    title: entry.data.title,
+    description: entry.data.summary,
+    url: meta.canonical,
+    image: entry.data.thumbnail,
+    datePublished: entry.data.publishedAt,
+    dateModified: entry.data.updatedAt,
+    keywords: entry.data.keywords,
+    authorName: "Sharron Mooks",
+    type: "BlogPosting",
+  }))}/>
+  <script type="application/ld+json" set:html={JSON.stringify(breadcrumbJsonLd([
+    { name: "Home", url: new URL("/", url).toString() },
+    { name: "Writing", url: new URL("/writing", url).toString() },
+    { name: entry.data.title, url: meta.canonical },
+  ]))}/>
+</Base>


### PR DESCRIPTION
## Summary
- add base layout with canonical and meta tags
- implement related content rail
- create case study, system win, and writing detail templates with SEO helpers

## Testing
- `npm test` *(fails: Missing script "test")*
- `pnpm build`

------
https://chatgpt.com/codex/tasks/task_e_68ab593a0cdc83308bffefcc1beebe93