### PR TITLE
feat: add global layout with header and footer

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -6,4 +6,11 @@ import sitemap from '@astrojs/sitemap';
 export default defineConfig({
   site: 'https://www.smooks.co.uk',
   integrations: [tailwind(), mdx(), sitemap()],
+  vite: {
+    resolve: {
+      alias: {
+        '@': '/src',
+      },
+    },
+  },
 });

--- a/src/components/CaseStudyLayout.astro
+++ b/src/components/CaseStudyLayout.astro
@@ -1,4 +1,5 @@
 ---
+import Base from "@/layouts/Base.astro";
 import type { CaseStudy } from "../data/caseStudies";
 
 interface Props {
@@ -57,46 +58,37 @@ const jsonLd = {
     targetName: code,
   })),
 };
+const url = new URL(Astro.request.url).toString();
 ---
+<Base title={`${title} · Case Study · SMooks`} description={summary} canonical={url}>
+  <main class="mx-auto max-w-3xl px-4 md:px-6 py-10">
+    <a href="/case-studies" class="text-sm text-zinc-500 hover:text-zinc-700 dark:text-zinc-400 dark:hover:text-zinc-200">&larr; Back to Case Studies</a>
+    <header class="mt-3 mb-6">
+      <h1 class="text-3xl md:text-4xl font-bold tracking-tight">{title}</h1>
+      <p class="mt-2 text-zinc-600 dark:text-zinc-300">{summary}</p>
+      <p class="mt-2 text-sm text-zinc-500 dark:text-zinc-400">
+        {new Date(date).toLocaleDateString(undefined, { year: "numeric", month: "long", day: "2-digit" })}
+      </p>
+      <div class="mt-4 flex flex-wrap gap-2">
+        {units.map((u) => (
+          <span class="text-xs rounded-full px-2.5 py-1 bg-zinc-100 dark:bg-zinc-800 text-zinc-700 dark:text-zinc-300 border border-zinc-200/60 dark:border-zinc-700/60">{u}</span>
+        ))}
+      </div>
+    </header>
 
-<html lang="en" class="scroll-pt-24">
-  <head>
-    <meta charset="utf-8" />
-    <meta name="viewport" content="width=device-width" />
-    <title>{title} · Case Study · SMooks</title>
-    <meta name="description" content={summary} />
-    <script type="application/ld+json">{JSON.stringify(jsonLd)}</script>
-  </head>
-  <body class="bg-white dark:bg-black text-zinc-900 dark:text-zinc-50">
-    <main class="mx-auto max-w-3xl px-4 md:px-6 py-10">
-      <a href="/case-studies" class="text-sm text-zinc-500 hover:text-zinc-700 dark:text-zinc-400 dark:hover:text-zinc-200">&larr; Back to Case Studies</a>
-      <header class="mt-3 mb-6">
-        <h1 class="text-3xl md:text-4xl font-bold tracking-tight">{title}</h1>
-        <p class="mt-2 text-zinc-600 dark:text-zinc-300">{summary}</p>
-        <p class="mt-2 text-sm text-zinc-500 dark:text-zinc-400">
-          {new Date(date).toLocaleDateString(undefined, { year: "numeric", month: "long", day: "2-digit" })}
-        </p>
-        <div class="mt-4 flex flex-wrap gap-2">
-          {units.map((u) => (
-            <span class="text-xs rounded-full px-2.5 py-1 bg-zinc-100 dark:bg-zinc-800 text-zinc-700 dark:text-zinc-300 border border-zinc-200/60 dark:border-zinc-700/60">{u}</span>
+    <article class="prose prose-zinc dark:prose-invert max-w-none">
+      <div set:html={code} />
+    </article>
+
+    {tags.length ? (
+      <footer class="mt-10 border-t border-zinc-200/60 dark:border-zinc-800/80 pt-6">
+        <div class="flex flex-wrap gap-2">
+          {tags.map((t) => (
+            <span class="text-xs uppercase tracking-wide rounded px-2 py-0.5 bg-zinc-50 dark:bg-zinc-800 text-zinc-500 dark:text-zinc-400 border border-zinc-200/50 dark:border-zinc-700/50">{t}</span>
           ))}
         </div>
-      </header>
-
-      <article class="prose prose-zinc dark:prose-invert max-w-none">
-        <div set:html={code} />
-      </article>
-
-      {tags.length ? (
-        <footer class="mt-10 border-t border-zinc-200/60 dark:border-zinc-800/80 pt-6">
-          <div class="flex flex-wrap gap-2">
-            {tags.map((t) => (
-              <span class="text-xs uppercase tracking-wide rounded px-2 py-0.5 bg-zinc-50 dark:bg-zinc-800 text-zinc-500 dark:text-zinc-400 border border-zinc-200/50 dark:border-zinc-700/50">{t}</span>
-            ))}
-          </div>
-        </footer>
-      ) : null}
-    </main>
-  </body>
-  </html>
-
+      </footer>
+    ) : null}
+  </main>
+  <script type="application/ld+json" set:html={JSON.stringify(jsonLd)} />
+</Base>

--- a/src/components/SiteHeader.astro
+++ b/src/components/SiteHeader.astro
@@ -1,7 +1,7 @@
 ---
-/* src/components/Header.astro */
+/* src/components/SiteHeader.astro */
 ---
-<header class="sticky top-0 z-50 backdrop-blur supports-[backdrop-filter]:bg-opacity-80 bg-[color:var(--color-bg)]/80 border-b" style="border-color: var(--color-border);">
+<header class="sticky top-0 z-40 bg-white/80 backdrop-blur border-b">
   <div class="mx-auto max-w-6xl px-6 md:px-8 h-16 flex items-center justify-between">
     <a href="/" class="font-heading text-lg md:text-xl font-semibold no-underline">SMooks</a>
     <nav class="hidden md:flex gap-6">

--- a/src/layouts/Base.astro
+++ b/src/layouts/Base.astro
@@ -1,6 +1,17 @@
 ---
-const { title = "SMooks", description = "Strategic Systems Architect & Transformation Leader", canonical, meta = [] } = Astro.props as {
-  title?: string; description?: string; canonical?: string; meta?: {name?:string; property?:string; content:string}[];
+import SiteHeader from "@/components/SiteHeader.astro";
+import SiteFooter from "@/components/SiteFooter.astro";
+
+const {
+  title = "SMooks",
+  description = "Strategic Systems Architect & Transformation Leader",
+  canonical,
+  meta = [],
+} = Astro.props as {
+  title?: string;
+  description?: string;
+  canonical?: string;
+  meta?: { name?: string; property?: string; content: string }[];
 };
 ---
 <html lang="en">
@@ -12,7 +23,11 @@ const { title = "SMooks", description = "Strategic Systems Architect & Transform
     {canonical && <link rel="canonical" href={canonical} />}
     {meta.map((m) => <meta {...m} />)}
   </head>
-  <body class="min-h-screen bg-white text-gray-900 antialiased">
-    <slot />
+  <body class="min-h-screen flex flex-col bg-white text-gray-900 antialiased">
+    <SiteHeader />
+    <main class="flex-1">
+      <slot />
+    </main>
+    <SiteFooter />
   </body>
 </html>

--- a/src/pages/404.astro
+++ b/src/pages/404.astro
@@ -1,11 +1,12 @@
-<html lang="en">
-  <head>
-    <title>Not found — SMooks</title>
-    <meta name="robots" content="noindex"/>
-  </head>
-  <body class="mx-auto max-w-3xl px-4 sm:px-6 lg:px-8 py-24 text-center">
+---
+import Base from "@/layouts/Base.astro";
+
+const url = new URL(Astro.request.url).toString();
+---
+<Base title="Not found — SMooks" canonical={url}>
+  <section class="mx-auto max-w-3xl px-4 sm:px-6 lg:px-8 py-24 text-center">
     <h1 class="text-4xl font-bold">Page not found</h1>
     <p class="mt-3 text-gray-600">Sorry — the page you’re looking for doesn’t exist.</p>
     <a href="/" class="mt-6 inline-block rounded-2xl bg-gray-900 px-5 py-3 text-white">Go home</a>
-  </body>
-</html>
+  </section>
+</Base>

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -1,8 +1,10 @@
-<html lang="en">
-  <head>
-    <title>About — SMooks</title>
-  </head>
-  <body class="mx-auto max-w-3xl px-4 sm:px-6 lg:px-8 py-12">
+---
+import Base from "@/layouts/Base.astro";
+
+const url = new URL(Astro.request.url).toString();
+---
+<Base title="About — SMooks" canonical={url}>
+  <section class="mx-auto max-w-3xl px-4 sm:px-6 lg:px-8 py-12">
     <h1 class="text-3xl font-bold">About</h1>
     <p class="mt-4 text-gray-700">
       I’m Sharron “SMooks” Mooks — a strategic, systems-focused education leader. I design and deliver scalable,
@@ -17,6 +19,5 @@
     <p class="mt-4 text-gray-700">
       Beyond work, I coach and mentor, love big landscapes, and believe culture changes when systems do.
     </p>
-  </body>
-</html>
-
+  </section>
+</Base>

--- a/src/pages/accessibility.astro
+++ b/src/pages/accessibility.astro
@@ -1,7 +1,9 @@
 ---
-import Layout from '@/layouts/Layout.astro';
+import Base from "@/layouts/Base.astro";
+
+const url = new URL(Astro.request.url).toString();
 ---
-<Layout title="Accessibility">
+<Base title="Accessibility" canonical={url}>
   <main class="prose mx-auto py-10">
     <h1>Accessibility Statement</h1>
     <p>Committed to WCAG 2.2 AA. Known issues & target dates listed below.</p>
@@ -12,4 +14,4 @@ import Layout from '@/layouts/Layout.astro';
     </ul>
     <p>Report an issue: accessibility@smooks.co.uk</p>
   </main>
-</Layout>
+</Base>

--- a/src/pages/case-studies/index.astro
+++ b/src/pages/case-studies/index.astro
@@ -1,46 +1,35 @@
 ---
-export const prerender = true;
-import CaseStudyCard from "../../components/CaseStudyCard.astro";
-import caseStudies from "../../data/caseStudies";
+import Base from "@/layouts/Base.astro";
+import CaseStudyCard from "@/components/CaseStudyCard.astro";
+import caseStudies from "@/data/caseStudies";
 
 const items = [...caseStudies].sort(
   (a, b) => new Date(b.date).getTime() - new Date(a.date).getTime()
 );
+
+const url = new URL(Astro.request.url).toString();
 ---
+<Base title="Case Studies · SMooks" description="CMI Level 7-aligned case studies demonstrating strategic leadership, change, policy, and systems design." canonical={url}>
+  <main class="mx-auto max-w-6xl px-4 md:px-6 py-10">
+    <header class="mb-8">
+      <h1 class="text-3xl md:text-4xl font-bold tracking-tight">Case Studies</h1>
+      <p class="mt-2 text-zinc-600 dark:text-zinc-300 max-w-3xl">
+        A concise collection mapped to CMI Level 7 units, showcasing strategic change, policy design, data-informed
+        delivery, and systems architecture.
+      </p>
+    </header>
 
-<html lang="en">
-  <head>
-    <meta charset="utf-8" />
-    <meta name="viewport" content="width=device-width" />
-    <title>Case Studies · SMooks</title>
-    <meta
-      name="description"
-      content="CMI Level 7-aligned case studies demonstrating strategic leadership, change, policy, and systems design."
-    />
-  </head>
-  <body class="bg-white dark:bg-black text-zinc-900 dark:text-zinc-50">
-    <main class="mx-auto max-w-6xl px-4 md:px-6 py-10">
-      <header class="mb-8">
-        <h1 class="text-3xl md:text-4xl font-bold tracking-tight">Case Studies</h1>
-        <p class="mt-2 text-zinc-600 dark:text-zinc-300 max-w-3xl">
-          A concise collection mapped to CMI Level 7 units, showcasing strategic change, policy design, data-informed
-          delivery, and systems architecture.
-        </p>
-      </header>
-
-      <section class="grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
-        {items.map((cs) => (
-          <CaseStudyCard
-            href={`/case-studies/${cs.slug}/`}
-            title={cs.title}
-            summary={cs.summary}
-            units={cs.units}
-            date={cs.date}
-            tags={cs.tags}
-          />
-        ))}
-      </section>
-    </main>
-  </body>
-  </html>
-
+    <section class="grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
+      {items.map((cs) => (
+        <CaseStudyCard
+          href={`/case-studies/${cs.slug}/`}
+          title={cs.title}
+          summary={cs.summary}
+          units={cs.units}
+          date={cs.date}
+          tags={cs.tags}
+        />
+      ))}
+    </section>
+  </main>
+</Base>

--- a/src/pages/contact.astro
+++ b/src/pages/contact.astro
@@ -1,8 +1,10 @@
-<html lang="en">
-  <head>
-    <title>Contact — SMooks</title>
-  </head>
-  <body class="mx-auto max-w-2xl px-4 sm:px-6 lg:px-8 py-12">
+---
+import Base from "@/layouts/Base.astro";
+
+const url = new URL(Astro.request.url).toString();
+---
+<Base title="Contact — SMooks" canonical={url}>
+  <section class="mx-auto max-w-2xl px-4 sm:px-6 lg:px-8 py-12">
     <h1 class="text-3xl font-bold">Contact</h1>
     <p class="mt-3 text-gray-700">I welcome strategic conversations, collaborations, and opportunities to scale transformation.</p>
 
@@ -26,6 +28,5 @@
     <div class="mt-6 text-sm text-gray-600">
       Or email me directly: <a class="underline" href="mailto:hello@smooks.co.uk">hello@smooks.co.uk</a>
     </div>
-  </body>
-</html>
-
+  </section>
+</Base>

--- a/src/pages/evidence/matrix.astro
+++ b/src/pages/evidence/matrix.astro
@@ -1,10 +1,11 @@
 ---
-import BaseLayout from '@/layouts/BaseLayout.astro';
+import Base from "@/layouts/Base.astro";
 import { getCollection } from 'astro:content';
 const entries = await getCollection('case-studies');
 const UNITS = ['701','702','703','704','705','706','707','708','709','710','711','712','713','714','715','716'];
+const url = new URL(Astro.request.url).toString();
 ---
-<BaseLayout title="Portfolio × CMI Matrix">
+<Base title="Portfolio × CMI Matrix" canonical={url}>
   <section class="container mx-auto px-4 py-10">
     <h1 class="text-3xl md:text-4xl font-semibold mb-6">Portfolio × CMI Evidence Matrix</h1>
     <div class="overflow-x-auto border rounded-2xl">
@@ -28,4 +29,4 @@ const UNITS = ['701','702','703','704','705','706','707','708','709','710','711'
       </table>
     </div>
   </section>
-</BaseLayout>
+</Base>

--- a/src/pages/playbooks.astro
+++ b/src/pages/playbooks.astro
@@ -1,12 +1,13 @@
 ---
-import Layout from "../layouts/BaseLayout.astro";
+import Base from "@/layouts/Base.astro";
 import { getCollection } from "astro:content";
 
 const playbooks = await getCollection("playbooks");
 const title = "Playbooks";
 const description = "Reusable frameworks and checklists.";
+const url = new URL(Astro.request.url).toString();
 ---
-<Layout {title} {description} currentPath={Astro.url.pathname}>
+<Base {title} {description} canonical={url}>
   <section class="mx-auto max-w-6xl">
     <h1 class="text-3xl md:text-4xl font-semibold">Playbooks</h1>
     <p class="text-zinc-400 mt-2 max-w-3xl">Frameworks you can reuse across schools and sectors.</p>
@@ -37,4 +38,4 @@ const description = "Reusable frameworks and checklists.";
       </ul>
     )}
   </section>
-</Layout>
+</Base>

--- a/src/pages/playbooks/[slug].astro
+++ b/src/pages/playbooks/[slug].astro
@@ -1,7 +1,7 @@
 ---
 export const prerender = true;
 
-import Layout from "../../layouts/BaseLayout.astro";
+import Base from "@/layouts/Base.astro";
 import { getCollection } from "astro:content";
 
 export async function getStaticPaths() {
@@ -16,8 +16,9 @@ const { entry } = Astro.props as { entry: any };
 const { Content } = await entry.render();
 const title = entry.data.title ?? `Playbook: ${entry.slug}`;
 const description = entry.data.summary ?? "Reusable framework.";
+const url = new URL(Astro.request.url).toString();
 ---
-<Layout {title} {description} currentPath={Astro.url.pathname}>
+<Base {title} {description} canonical={url}>
   <section class="mx-auto max-w-3xl">
     <a href="/playbooks" class="text-sm text-zinc-400 hover:underline">← Back to Playbooks</a>
     <h1 class="mt-2 text-3xl md:text-4xl font-semibold">{title}</h1>
@@ -35,4 +36,4 @@ const description = entry.data.summary ?? "Reusable framework.";
       </div>
     )}
   </section>
-</Layout>
+</Base>

--- a/src/pages/portfolio/[box].astro
+++ b/src/pages/portfolio/[box].astro
@@ -1,14 +1,11 @@
 ---
-// make sure this page is statically generated
 export const prerender = true;
 
-import Layout from "../../layouts/BaseLayout.astro";
-import { getStreamBySlug, winsForStream, STREAMS } from "../../data/wins";
-import SystemWinsCard from "../../components/SystemWinsCard.astro";
+import Base from "@/layouts/Base.astro";
+import { getStreamBySlug, winsForStream, STREAMS } from "@/data/wins";
+import SystemWinsCard from "@/components/SystemWinsCard.astro";
 
-// 👇 ADD THIS
 export function getStaticPaths() {
-  // Expect STREAMS like: [{ slug: "strategy", name: "...", blurb: "..." }, ...]
   return STREAMS.map((s) => ({ params: { box: s.slug } }));
 }
 
@@ -22,8 +19,9 @@ if (!stream) {
 const wins = winsForStream(stream.name);
 const title = `${stream.name} – Portfolio`;
 const description = stream.blurb;
+const url = new URL(Astro.request.url).toString();
 ---
-<Layout {title} {description} currentPath={Astro.url.pathname}>
+<Base {title} {description} canonical={url}>
   <section class="mx-auto max-w-6xl">
     <a href="/portfolio" class="text-sm text-zinc-400 hover:underline">← Back to Portfolio</a>
     <h1 class="mt-2 text-3xl md:text-4xl font-semibold">{stream.name}</h1>
@@ -49,4 +47,4 @@ const description = stream.blurb;
       </div>
     )}
   </section>
-</Layout>
+</Base>

--- a/src/pages/portfolio/index.astro
+++ b/src/pages/portfolio/index.astro
@@ -1,4 +1,5 @@
 ---
+import Base from "@/layouts/Base.astro";
 import PortfolioBrowser from "@/components/PortfolioBrowser.astro";
 import { getCollection } from "astro:content";
 import { slugify } from "@/utils/slugify";
@@ -16,27 +17,19 @@ const toItem = (type: "Case Study" | "System Win" | "Writing") => (e: any) => ({
   category: e.data.category ?? [],
   tags: e.data.tags ?? [],
   cmi: e.data.cmi ?? [],
-  thumbnail: e.data.thumbnail
+  thumbnail: e.data.thumbnail,
 });
 
-const items = [
-  ...cs.map(toItem("Case Study")),
-  ...sw.map(toItem("System Win")),
-  ...wr.map(toItem("Writing"))
-].sort((a,b)=> b.year - a.year);
+const items = [...cs.map(toItem("Case Study")), ...sw.map(toItem("System Win")), ...wr.map(toItem("Writing"))]
+  .sort((a, b) => b.year - a.year);
+
+const url = new URL(Astro.request.url).toString();
 ---
-
-<html lang="en">
-  <head>
-    <title>Portfolio — SMooks</title>
-  </head>
-  <body class="py-8">
-    <header class="mx-auto max-w-6xl px-4 sm:px-6 lg:px-8">
-      <h1 class="text-3xl font-bold">Portfolio</h1>
-      <p class="mt-2 text-gray-600">Filterable, searchable collection of case studies, systems wins, and writing.</p>
-    </header>
-
-    <PortfolioBrowser items={items} />
-    <script type="application/json" id="items-data">{JSON.stringify(items)}</script>
-  </body>
-</html>
+<Base title="Portfolio — SMooks" description="Filterable, searchable collection of case studies, systems wins, and writing." canonical={url}>
+  <header class="mx-auto max-w-6xl px-4 sm:px-6 lg:px-8 py-8">
+    <h1 class="text-3xl font-bold">Portfolio</h1>
+    <p class="mt-2 text-gray-600">Filter and search across case studies, systems wins, and writing.</p>
+  </header>
+  <PortfolioBrowser items={items} />
+  <script type="application/json" id="items-data">{JSON.stringify(items)}</script>
+</Base>

--- a/src/pages/privacy.astro
+++ b/src/pages/privacy.astro
@@ -1,7 +1,9 @@
 ---
-import Layout from '@/layouts/Layout.astro';
+import Base from "@/layouts/Base.astro";
+
+const url = new URL(Astro.request.url).toString();
 ---
-<Layout title="Privacy">
+<Base title="Privacy" canonical={url}>
   <main class="prose mx-auto py-10">
     <h1>Privacy</h1>
     <p>No cookies; using privacy-friendly analytics only. You can contact me at …</p>
@@ -12,4 +14,4 @@ import Layout from '@/layouts/Layout.astro';
     <h2>Your rights</h2>
     <p>UK GDPR rights to access, rectification, erasure…</p>
   </main>
-</Layout>
+</Base>

--- a/src/pages/streams/[stream].astro
+++ b/src/pages/streams/[stream].astro
@@ -1,5 +1,5 @@
 ---
-import BaseLayout from "@/layouts/BaseLayout.astro";
+import Base from "@/layouts/Base.astro";
 import { getCollection } from 'astro:content';
 export async function getStaticPaths() {
   return [
@@ -17,8 +17,9 @@ const LABELS: Record<string,string> = {
   'leadership-governance':'Leadership, Strategy & Governance',
   'innovation-growth':'Innovation & Growth',
 };
+const url = new URL(Astro.request.url).toString();
 ---
-<BaseLayout title={`${LABELS[stream]} — Case Studies`}>
+<Base title={`${LABELS[stream]} — Case Studies`} canonical={url}>
   <section class="container mx-auto px-4 py-10">
     <h1 class="text-3xl md:text-4xl font-semibold mb-6">{LABELS[stream]}</h1>
     <div class="grid md:grid-cols-2 gap-6">
@@ -34,4 +35,4 @@ const LABELS: Record<string,string> = {
       ))}
     </div>
   </section>
-</BaseLayout>
+</Base>

--- a/src/pages/streams/index.astro
+++ b/src/pages/streams/index.astro
@@ -1,5 +1,5 @@
 ---
-import BaseLayout from "@/layouts/BaseLayout.astro";
+import Base from "@/layouts/Base.astro";
 import { getCollection } from 'astro:content';
 const all = await getCollection('case-studies');
 const byStream = all.reduce((acc, item) => {
@@ -15,8 +15,9 @@ const STREAMS = [
   { key: 'leadership-governance', label: 'Leadership, Strategy & Governance' },
   { key: 'innovation-growth', label: 'Innovation & Growth' },
 ];
+const url = new URL(Astro.request.url).toString();
 ---
-<BaseLayout title="Transformation Streams">
+<Base title="Transformation Streams" canonical={url}>
   <section class="container mx-auto px-4 py-10">
     <h1 class="text-3xl md:text-4xl font-semibold mb-6">Transformation Streams</h1>
     <p class="mb-10 max-w-3xl">Browse case studies by stream. Each story links to CMI Level 7 evidence and metrics.</p>
@@ -29,4 +30,4 @@ const STREAMS = [
       ))}
     </div>
   </section>
-</BaseLayout>
+</Base>

--- a/src/pages/system-wins.astro
+++ b/src/pages/system-wins.astro
@@ -1,33 +1,33 @@
 ---
-import Layout from "../layouts/BaseLayout.astro";
-import SEO from "../components/SEO.astro";
+import Base from "@/layouts/Base.astro";
+import SEO from "@/components/SEO.astro";
 import { getCollection } from "astro:content";
 
-const wins = (await getCollection("wins"))
-  .sort((a, b) => +new Date(b.data.date) - +new Date(a.data.date));
+const wins = (await getCollection("wins")).sort((a, b) => +new Date(b.data.date) - +new Date(a.data.date));
+const url = new URL(Astro.request.url).toString();
 ---
-<Layout title="Systems Wins — SMooks" description="Measurable, repeatable improvements with data and governance." currentPath="/systems-wins">
+<Base title="Systems Wins — SMooks" description="Measurable, repeatable improvements with data and governance." canonical={url}>
   <SEO title="Systems Wins — SMooks" description="Evidence-backed case studies of systems change." />
-  <h1 class="text-3xl font-semibold mb-6">Systems Wins</h1>
+  <section class="mx-auto max-w-6xl px-4 sm:px-6 lg:px-8 py-12">
+    <h1 class="text-3xl font-semibold mb-6">Systems Wins</h1>
 
-  <ul class="grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
-    {wins.map((entry) => (
-      <li class="rounded-2xl border border-white/10 p-5 hover:border-white/20 transition">
-        <a href={`/system-wins/${entry.slug}`} class="block" aria-label={`Read case study: ${entry.data.title}`}>
-  …
-</a>
-          <h2 class="text-xl font-semibold mb-2">{entry.data.title}</h2>
-          <p class="text-sm text-zinc-400 mb-3">
-            {new Date(entry.data.date).toLocaleDateString("en-GB")}
-          </p>
-          <p class="text-zinc-200 mb-4">{entry.data.summary}</p>
-          <div class="flex flex-wrap gap-2">
-            {entry.data.tags?.map(t => (
-              <span class="text-xs px-2 py-1 rounded-full bg-white/10">{t}</span>
-            ))}
-          </div>
-        </a>
-      </li>
-    ))}
-  </ul>
-</Layout>
+    <ul class="grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
+      {wins.map((entry) => (
+        <li class="rounded-2xl border border-white/10 p-5 hover:border-white/20 transition">
+          <a href={`/system-wins/${entry.slug}`} class="block" aria-label={`Read case study: ${entry.data.title}`}>
+            <h2 class="text-xl font-semibold mb-2">{entry.data.title}</h2>
+            <p class="text-sm text-zinc-400 mb-3">
+              {new Date(entry.data.date).toLocaleDateString("en-GB")}
+            </p>
+            <p class="text-zinc-200 mb-4">{entry.data.summary}</p>
+            <div class="flex flex-wrap gap-2">
+              {entry.data.tags?.map(t => (
+                <span class="text-xs px-2 py-1 rounded-full bg-white/10">{t}</span>
+              ))}
+            </div>
+          </a>
+        </li>
+      ))}
+    </ul>
+  </section>
+</Base>

--- a/src/pages/writing.astro
+++ b/src/pages/writing.astro
@@ -1,14 +1,13 @@
-
 ---
-// src/pages/writing.astro
-import Layout from "../layouts/BaseLayout.astro";
+import Base from "@/layouts/Base.astro";
 import { getCollection } from "astro:content";
 
 const articles = await getCollection("articles");
 const title = "Writing";
 const description = "Articles and reflections.";
+const url = new URL(Astro.request.url).toString();
 ---
-<Layout {title} {description} currentPath={Astro.url.pathname}>
+<Base {title} {description} canonical={url}>
   <section class="mx-auto max-w-6xl">
     <h1 class="text-3xl md:text-4xl font-semibold">Writing</h1>
     <p class="text-zinc-400 mt-2 max-w-3xl">Essays, reflections, and cross-posts.</p>
@@ -39,4 +38,4 @@ const description = "Articles and reflections.";
       </ul>
     )}
   </section>
-</Layout>
+</Base>


### PR DESCRIPTION
## Summary
- add SiteHeader and SiteFooter to Base layout
- wrap all pages in Base layout for consistent header and footer
- configure @ alias in Astro config

## Testing
- `pnpm build`

------
https://chatgpt.com/codex/tasks/task_e_68ab60edcdf883308ba188aaddc0ab2c