### PR TITLE
Add portfolio content model and starter entries

### DIFF
--- a/src/components/PortfolioBrowser.astro
+++ b/src/components/PortfolioBrowser.astro
@@ -25,14 +25,46 @@ const { items } = Astro.props as { items: PortfolioItem[] };
   <div class="mb-2 text-xs uppercase tracking-wide text-gray-500">Project Types</div>
   <div class="mb-6 flex flex-wrap gap-2" id="projects"></div>
 
-  <div id="results" class="grid gap-6 sm:grid-cols-2 lg:grid-cols-3"></div>
+  <div id="results" class="grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
+    {items.map((i) => (
+      <a
+        href={`/${i.type === "Writing" ? "writing" : i.type === "System Win" ? "system-wins" : "portfolio"}/${i.slug}`}
+        class="block rounded-2xl border hover:shadow-lg transition p-4"
+      >
+        {i.thumbnail && (
+          <img
+            src={i.thumbnail}
+            alt=""
+            class="mb-3 aspect-video w-full rounded-xl object-cover"
+          />
+        )}
+        <div class="flex items-center justify-between">
+          <span class="text-xs uppercase tracking-wide text-gray-500">{i.type}</span>
+          <span class="text-xs text-gray-500">{i.year}</span>
+        </div>
+        <h3 class="mt-1 text-lg font-semibold">{i.title}</h3>
+        <p class="mt-1 text-sm text-gray-600">{i.summary}</p>
+        <div class="mt-3 flex flex-wrap gap-1">
+          {i.streams.slice(0, 1).map((t) => (
+            <span class="rounded-full bg-gray-100 px-2 py-0.5 text-xs">{t}</span>
+          ))}
+          {i.industries.slice(0, 1).map((t) => (
+            <span class="rounded-full bg-gray-100 px-2 py-0.5 text-xs">{t}</span>
+          ))}
+          {i.projectTypes.slice(0, 1).map((t) => (
+            <span class="rounded-full bg-gray-100 px-2 py-0.5 text-xs">{t}</span>
+          ))}
+        </div>
+      </a>
+    ))}
+  </div>
 </section>
 
 <!-- 1) put the data INSIDE the component -->
 <script type="application/json" id="items-data">{JSON.stringify(items)}</script>
 
 <!-- 2) inline the script so it runs after the JSON above -->
-<script is:inline>
+<script is:inline type="module">
   import { makeIndex } from "../lib/search/fuse";
 
   // read JSON right above this tag (guaranteed order)
@@ -112,6 +144,8 @@ const { items } = Astro.props as { items: PortfolioItem[] };
     }
   }
 
-  [$q,$type,$year].forEach(el=>el.addEventListener("input", render));
+  $q.addEventListener("input", render);
+  $type.addEventListener("change", render);
+  $year.addEventListener("change", render);
   render();
 </script>

--- a/src/content/config.ts
+++ b/src/content/config.ts
@@ -46,4 +46,36 @@ const writing = defineCollection({
   }),
 });
 
-export const collections = { caseStudies, systemWins, writing };
+const portfolio = defineCollection({
+  type: "content",
+  schema: z.object({
+    title: z.string(),
+    slug: z.string().optional(),
+    date: z.date(),
+    type: z.enum(["system-win", "case-study", "writing"]),
+    streams: z.array(
+      z.enum([
+        "Technology & Digital Transformation",
+        "Governance & Risk",
+        "Operational Excellence",
+        "People & Culture",
+        "Teaching & Learning",
+        "Data & Analytics",
+      ])
+    ).default([]),
+    industry: z.array(z.string()).default(["Education"]),
+    projectType: z.array(z.string()).default([]),
+    tags: z.array(z.string()).default([]),
+    cmiUnits: z.array(z.string()).default([]),
+    summary: z.string(),
+    metrics: z
+      .array(z.object({ label: z.string(), value: z.string() }))
+      .default([]),
+    featured: z.boolean().default(false),
+    cover: z.string().optional(),
+    externalUrl: z.string().optional(),
+    published: z.boolean().default(true),
+  }),
+});
+
+export const collections = { caseStudies, systemWins, writing, portfolio };

--- a/src/content/portfolio/2023-01-15-slt-portal.md
+++ b/src/content/portfolio/2023-01-15-slt-portal.md
@@ -1,0 +1,17 @@
+---
+title: "SLT Portal — one place for leaders to act"
+date: 2023-01-15
+type: "system-win"
+streams: ["Operational Excellence","Technology & Digital Transformation","Data & Analytics"]
+industry: ["Education"]
+projectType: ["SharePoint","IA","Dashboards"]
+tags: ["single-pane","decision-support"]
+cmiUnits: ["701","704"]
+summary: "Consolidated critical tools & insights for senior leaders; reduced context switching and drift."
+metrics: []
+featured: false
+published: true
+---
+
+Designed for speed-to-decision and reliable daily rhythm.
+

--- a/src/content/portfolio/2023-11-10-maintenance-logging-automation.md
+++ b/src/content/portfolio/2023-11-10-maintenance-logging-automation.md
@@ -1,0 +1,18 @@
+---
+title: "Maintenance Logging — from manual to automated"
+date: 2023-11-10
+type: "system-win"
+streams: ["Operational Excellence","Technology & Digital Transformation"]
+industry: ["Education"]
+projectType: ["Power Automate","SharePoint","Ops"]
+tags: ["automation","throughput","service-desk"]
+cmiUnits: ["705","703"]
+summary: "Logged site repairs via simple, reliable flows; reduced duplicate entry and sped up fixes."
+metrics:
+  - { label: "Admin time saved", value: "Meaningful reduction (tracked locally)" }
+featured: false
+published: true
+---
+
+A repeatable pattern for low‑friction service capture and resolution tracking.
+

--- a/src/content/portfolio/2024-12-12-maths-curriculum-library.md
+++ b/src/content/portfolio/2024-12-12-maths-curriculum-library.md
@@ -1,0 +1,18 @@
+---
+title: "Maths Curriculum Library — meta-tagged, predictable, fast"
+date: 2024-12-12
+type: "system-win"
+streams: ["Teaching & Learning","Technology & Digital Transformation","Operational Excellence"]
+industry: ["Education"]
+projectType: ["SharePoint","IA","Content Ops"]
+tags: ["findability","metadata","teacher-experience"]
+cmiUnits: ["703","705"]
+summary: "SharePoint-hosted resource library with consistent structure and tags so teachers find the right thing in seconds."
+metrics:
+  - { label: "Outcome", value: "Less hunting, more teaching" }
+featured: false
+published: true
+---
+
+Implemented robust naming, tagging, and folder discipline; preview foreshadowed full rollout to build momentum.
+

--- a/src/content/portfolio/2025-02-11-timeoff-approvals-flow.md
+++ b/src/content/portfolio/2025-02-11-timeoff-approvals-flow.md
@@ -1,0 +1,18 @@
+---
+title: "Time Off Approvals — resumable, multi‑stakeholder flow"
+date: 2025-02-11
+type: "system-win"
+streams: ["Operational Excellence","Technology & Digital Transformation","Governance & Risk"]
+industry: ["Education"]
+projectType: ["Power Automate","Lists","Calendars"]
+tags: ["workflow","notifications","audit"]
+cmiUnits: ["705","708"]
+summary: "Automated requests with approvals, calendar updates, and leader notifications; reduced email ping‑pong."
+metrics:
+  - { label: "Failure rate", value: "Low; designed for resumable states" }
+featured: false
+published: true
+---
+
+Built for real‑world interruptions and clear auditability.
+

--- a/src/content/portfolio/2025-04-04-raci-hats-framework.md
+++ b/src/content/portfolio/2025-04-04-raci-hats-framework.md
@@ -1,0 +1,18 @@
+---
+title: "RACI Hats — scalable role clarity across functions"
+date: 2025-04-04
+type: "system-win"
+streams: ["Operational Excellence","Governance & Risk","People & Culture"]
+industry: ["Education"]
+projectType: ["Framework","Governance","Power BI"]
+tags: ["role-clarity","ownership","visibility"]
+cmiUnits: ["701","704","708"]
+summary: "Tiered RACI with strategic/functional/operational views; links people to roles and visualises responsibilities."
+metrics:
+  - { label: "Clarity", value: "Reduces decision friction; faster handoffs" }
+featured: false
+published: true
+---
+
+Built to integrate with existing systems and surface accountability without blame.
+

--- a/src/content/portfolio/2025-05-23-printer-replacement-win.md
+++ b/src/content/portfolio/2025-05-23-printer-replacement-win.md
@@ -1,0 +1,19 @@
+---
+title: "Strategic Printer Replacement — reliability, cost, and flow"
+date: 2025-05-23
+type: "system-win"
+streams: ["Operational Excellence","Data & Analytics"]
+industry: ["Education"]
+projectType: ["Ops","Procurement","Data"]
+tags: ["reliability","downtime-reduction"]
+cmiUnits: ["705","710"]
+summary: "Data-led case to replace failing kit causing 80% downtime. Balanced load, reduced friction, improved service."
+metrics:
+  - { label: "Downtime (old)", value: "≈80%" }
+  - { label: "Result", value: "Load-balanced fleet; reduced service pressure" }
+featured: false
+published: true
+---
+
+A small, visible win that demonstrates systems thinking and stakeholder engagement for cost‑effective outcomes.
+

--- a/src/content/portfolio/2025-06-01-rome-vs-empire.md
+++ b/src/content/portfolio/2025-06-01-rome-vs-empire.md
@@ -1,0 +1,18 @@
+---
+title: "Rome vs Empire — a framework for intentional system design"
+date: 2025-06-01
+type: "writing"
+streams: ["Operational Excellence","Technology & Digital Transformation","Governance & Risk"]
+industry: ["Education","Public Sector"]
+projectType: ["Strategy","Framework"]
+tags: ["architecture","app-sprawl","operating-model"]
+cmiUnits: ["704","701"]
+summary: "Stop adding apps. Build Rome (your backbone) first; let the Empire orbit it. A decision framework with principles and a practical roadmap."
+metrics: []
+featured: false
+externalUrl: ""
+published: true
+---
+
+Short essay and toolkit used to evaluate whether a tool is worthy of the ‘Empire’. Helps leaders choose architecture over accumulation.
+

--- a/src/content/portfolio/2025-06-16-ai-policy-responsible-use.md
+++ b/src/content/portfolio/2025-06-16-ai-policy-responsible-use.md
@@ -1,0 +1,19 @@
+---
+title: "AI Policy — Responsible Use across Schools & Support Services"
+date: 2025-06-16
+type: "system-win"
+streams: ["Governance & Risk","Technology & Digital Transformation"]
+industry: ["Education"]
+projectType: ["Policy","Risk","Compliance"]
+tags: ["UK GDPR","Safeguarding","ISO 27001","ISO 42001"]
+cmiUnits: ["708","610","704"]
+summary: "Best‑practice, pragmatic policy balancing risk and opportunity; aligned to UK GDPR and safeguarding law; adopted group‑wide."
+metrics:
+  - { label: "Scope", value: "Education + operations + support services" }
+  - { label: "Impact", value: "Consistent guardrails; enables safe experimentation" }
+featured: true
+published: true
+---
+
+Practical policy that leaders and practitioners can follow, with clear do/don’t patterns, DPIA hooks, and escalation paths. Built to **unlock** safe value, not just restrict it.
+

--- a/src/content/portfolio/2025-07-24-regional-staff-awards-system.md
+++ b/src/content/portfolio/2025-07-24-regional-staff-awards-system.md
@@ -1,0 +1,33 @@
+---
+title: "Regional Staff Awards System — student-led, trust-first design"
+date: 2025-07-24
+type: "case-study"
+streams: ["People & Culture","Technology & Digital Transformation","Operational Excellence"]
+industry: ["Education"]
+projectType: ["SharePoint","Power Automate","Comms","Service Design"]
+tags: ["peer-nomination","behavioural-design","Rome/Empire","trust-rebuild"]
+cmiUnits: ["705","703","701"]
+summary: "Co-designed with students; rebuilt recognition around peer nominations and simple, transparent flow. Launched regionally with high engagement."
+metrics:
+  - { label: "Nominations (Year 1)", value: "1,147 across 7 schools" }
+  - { label: "Adoption", value: "Strongest engagement vs previous initiatives" }
+  - { label: "Student impact", value: "Systems design & leadership experience" }
+featured: true
+published: true
+---
+
+**Context**  
+Recognition felt top‑down and distrusted. Brief was vague. We wireframed end‑to‑end, tested an MVP in a separate tenant, and anchored engagement on **peer nominations** to rebuild trust.
+
+**Action**  
+- Information architecture + comms flow (how people hear, access, nominate).  
+- Power Automate + Lists + SharePoint front-end.  
+- Transparent shortlisting & winner selection mechanics.  
+- Risk + failure modes rehearsed; relentless pre‑flight testing.
+
+**Outcome / Value**  
+- High trust, high participation; students gained real systems‑delivery experience.  
+- Reusable blueprint for future cultural change projects.
+
+**CMI mapping**: 705 (Strategic Change), 703 (Collaboration), 701 (Strategic Leadership).
+

--- a/src/pages/portfolio/index.astro
+++ b/src/pages/portfolio/index.astro
@@ -1,36 +1,36 @@
 ---
 import Base from "@/layouts/Base.astro";
+import SEO from "@/components/SEO.astro";
 import PortfolioBrowser from "@/components/PortfolioBrowser.astro";
 import { getCollection } from "astro:content";
 import { slugify } from "@/utils/slugify";
 
-// use the SAME ids you used in the working detail pages:
-const cs = await getCollection("caseStudies");   // or "case-studies" if that’s your config
-const sw = await getCollection("systemWins");    // or "system-wins"
-const wr = await getCollection("writing");
-
-const toItem = (type: "Case Study" | "System Win" | "Writing") => (e:any) => ({
-  slug: slugify(e.slug ?? e.id ?? e.data.title),
-  title: e.data.title,
-  summary: e.data.summary,
-  type,
-  year: e.data.year,
-  streams: e.data.streams ?? [],
-  industries: e.data.industries ?? [],
-  projectTypes: e.data.projectTypes ?? [],
-  tags: e.data.tags ?? [],
-  thumbnail: e.data.thumbnail
-});
-
-const items = [...cs.map(toItem("Case Study")), ...sw.map(toItem("System Win")), ...wr.map(toItem("Writing"))]
-  .sort((a,b)=>b.year-a.year);
+const entries = await getCollection("portfolio", ({ data }) => data.published !== false);
+const items = entries
+  .sort((a, b) => b.data.date.getTime() - a.data.date.getTime())
+  .map((e) => ({
+    slug: slugify(e.slug ?? e.id ?? e.data.title),
+    title: e.data.title,
+    summary: e.data.summary,
+    type:
+      e.data.type === "case-study"
+        ? "Case Study"
+        : e.data.type === "system-win"
+        ? "System Win"
+        : "Writing",
+    year: e.data.date.getUTCFullYear(),
+    streams: e.data.streams ?? [],
+    industries: e.data.industry ?? [],
+    projectTypes: e.data.projectType ?? [],
+    tags: e.data.tags ?? [],
+    thumbnail: e.data.cover,
+  }));
 
 const url = new URL(Astro.request.url).toString();
 ---
-<Base title="Portfolio — SMooks" description="Filterable, searchable portfolio: case studies, systems wins, and writing." canonical={url}>
-  <header class="mx-auto max-w-6xl px-4 sm:px-6 lg:px-8 py-8">
-    <h1 class="text-3xl font-bold">Portfolio</h1>
-    <p class="mt-2 text-gray-600">Search and filter by type, transformation streams, industry, and project type.</p>
-  </header>
+
+<Base title="Portfolio — SMooks" description="Case studies, system wins, and writing" canonical={url}>
+  <SEO title="Portfolio — SMooks" description="Case studies, system wins, and writing" />
   <PortfolioBrowser items={items} />
 </Base>
+


### PR DESCRIPTION
## Summary
- define `portfolio` content collection with structured fields
- seed portfolio with example entries and simple page to render cards
- restore portfolio page layout with header/footer and search UI
- pre-render portfolio items so the full library is visible with search filtering
- fix portfolio search script and relocate page to `/portfolio/index.astro`

## Testing
- `npx astro check` *(fails: @astrojs/check and typescript packages missing)*

------
https://chatgpt.com/codex/tasks/task_e_68ab7fec7c608330803d457a2f772500